### PR TITLE
Force `deepcopy(agent)` to shallow-copy `agent.world`

### DIFF
--- a/src/novel_swarms/agent/Agent.py
+++ b/src/novel_swarms/agent/Agent.py
@@ -325,7 +325,7 @@ class Agent:
         return cls(config, world)
 
     def copy(self):
-        """Create a copy of this agent
+        """Create a copy of this agent.
 
 
         Returns
@@ -333,10 +333,11 @@ class Agent:
         Agent
             The new agent has the same type as the class/instance it was called from.
 
+
         Almost all attributes are deep-copied from this agent. However, some attributes
         do not get recursively deep-copied, such as the ``world`` attribute.
 
-        The :py:attr:`_always_shallow_copy` attribute is a list of agent attribute names
+        The :py:attr:`Agent._always_shallow_copy` attribute is a list of agent attribute names
         which determines which attributes do not get deep-copied. By default, this is ``['world']``.
 
         On the new agent, Attributes of **this** agent not in this list will be a deep-copy of those in the original agent.

--- a/src/novel_swarms/agent/Agent.py
+++ b/src/novel_swarms/agent/Agent.py
@@ -325,6 +325,33 @@ class Agent:
         return cls(config, world)
 
     def copy(self):
+        """Create a copy of this agent
+
+
+        Returns
+        -------
+        Agent
+            The new agent has the same type as the class/instance it was called from.
+
+        Almost all attributes are deep-copied from this agent. However, some attributes
+        do not get recursively deep-copied, such as the ``world`` attribute.
+
+        The :py:attr:`_always_shallow_copy` attribute is a list of agent attribute names
+        which determines which attributes do not get deep-copied. By default, this is ``['world']``.
+
+        On the new agent, Attributes of **this** agent not in this list will be a deep-copy of those in the original agent.
+
+        Attributes of **this** agent in this list will share the same reference as the original agent.
+
+        Examples
+        --------
+        >>> agent = Agent(config, world)
+        >>> agent.copy().world is agent.world
+        True
+        >>> copy.deepcopy(agent).world is agent.world
+        False
+
+        """
         cls = self.__class__
         result = cls.__new__(cls)
         memo = {}

--- a/src/novel_swarms/agent/Agent.py
+++ b/src/novel_swarms/agent/Agent.py
@@ -324,9 +324,10 @@ class Agent:
         """
         return cls(config, world)
 
-    def __deepcopy__(self, memo):
+    def copy(self):
         cls = self.__class__
         result = cls.__new__(cls)
+        memo = {}
         memo[id(self)] = result
         for key, value in self.__dict__.items():
             if key in cls._always_shallow_copy:

--- a/src/novel_swarms/agent/Agent.py
+++ b/src/novel_swarms/agent/Agent.py
@@ -80,6 +80,8 @@ class BaseAgentConfig:
 
 class Agent:
 
+    _always_shallow_copy = ["world"]
+
     def __init__(self, config, world, name=None, group=0, initialize=True) -> None:
         self.marked_for_deletion = False
         #: Agent config.
@@ -321,3 +323,14 @@ class Agent:
             The new agent has the same type as the class/instance it was called from.
         """
         return cls(config, world)
+
+    def __deepcopy__(self, memo):
+        cls = self.__class__
+        result = cls.__new__(cls)
+        memo[id(self)] = result
+        for key, value in self.__dict__.items():
+            if key in cls._always_shallow_copy:
+                setattr(result, key, value)  # keep reference to same world, etc.
+            else:
+                setattr(result, key, copy.deepcopy(value, memo))
+        return result

--- a/src/novel_swarms/world/spawners/AgentSpawner.py
+++ b/src/novel_swarms/world/spawners/AgentSpawner.py
@@ -53,7 +53,11 @@ class BaseAgentSpawner(Spawner):
             self.agent_class, self.agent_config = None, None  # pyright: ignore[reportAttributeAccessIssue]
 
     def generate_config(self):
-        return copy.deepcopy(self.agent_config)
+        if isinstance(self.agent_config, BaseAgentConfig):
+            return copy.deepcopy(self.agent_config)
+        elif isinstance(self.agent_config, Agent):
+            return self.agent_config.copy()
+            
 
     def make_agent(self, config):
         if isinstance(self.agent_config, Agent):


### PR DESCRIPTION
Fix #4 by:

1. Introducing `_always_shallow_copy` as a class variable on `Agent` class.
   * `_agent_shallow_copy: list[str] = ['world']`
2. Overriding `agent.__deepcopy__()` to treat instance variables with names in `_always_shallow_copy` like `copy()` (shallow, i.e. do not recursively deepcopy `agent.world`)

The `new_agent.world` should refer to the same `world` instance as `agent.world`.