### PR TITLE
Fix polygon display flipped over x-axis issue

### DIFF
--- a/src/swarmsim/agent/StaticAgent.py
+++ b/src/swarmsim/agent/StaticAgent.py
@@ -149,6 +149,11 @@ class StaticAgent(Agent):
         return np.array([[np.cos(angle), -np.sin(angle)],
                          [np.sin(angle), np.cos(angle)]], dtype=np.float64)
 
+    def rotmat2dT(self, offset=0):  # small optimization over rotmat2d.T
+        angle = self.angle + offset
+        return np.array([[np.cos(angle), np.sin(angle)],
+                         [-np.sin(angle), np.cos(angle)]], dtype=np.float64)
+
     def rotmat3d(self, offset=None):
         angle = self.angle if offset is None else (self.angle + offset)
         return np.array([
@@ -159,9 +164,8 @@ class StaticAgent(Agent):
 
     @property
     def poly_rotated(self):
-        # transposing the rotation matrix here is a bit of a hack that fixes the fact that these are multiplied in the wrong order
-        # the proper way to do this is (self.rotmat2d() @ self.points.transpose()).transpose() but it is slower
-        return self.points @ self.rotmat2d().transpose() 
+        # the proper but less optimal way to do this is (self.rotmat2d() @ self.points.transpose()).transpose()
+        return self.points @ self.rotmat2dT()
 
     @override
     def draw(self, screen, offset=((0, 0), 1.0)) -> None:


### PR DESCRIPTION
Polygons are displayed flipped over the x-axis. This is because the rotation matrix was multiplied by the polygon points matrix in the wrong order. This branch contains the fix for this issue.