### PR TITLE
add load_all(loader=IncludeLoader) to our custom yaml

### DIFF
--- a/src/swarmsim/yaml/__init__.py
+++ b/src/swarmsim/yaml/__init__.py
@@ -54,6 +54,7 @@ from functools import partial
 yaml.add_constructor("!np", construct_numexpr, IncludeLoader)
 
 load = partial(yaml.load, Loader=IncludeLoader)
+load_all = partial(yaml.load_all, Loader=IncludeLoader)
 
 
 class NaiveLoader(yaml.SafeLoader):


### PR DESCRIPTION
Add the ability to load multiple documents from a single stream (see the [YAML spec 2.2](https://yaml.org/spec/1.2.2/#22-structures))

This was possible before but one would have had to:

```python
import yaml
from swarmsim.yaml import IncludeLoader

yaml.load_all(stream, loader=IncludeLoader)
```

Now, one should be able to:

```python
from swarmsim import yaml

yaml.load_all(stream)
```

This exists alongside the previous convenience functions such as `swarmsim.yaml.load()`.