### PR TITLE
Allow additional behavior to trigger for each agent added to a World's population

### DIFF
--- a/demo/population_hook_test.py
+++ b/demo/population_hook_test.py
@@ -1,0 +1,35 @@
+# from https://kenblu24.github.io/RobotSwarmSimulator/guide/firstrun.html
+
+from swarmsim.world.RectangularWorld import RectangularWorld, RectangularWorldConfig
+from swarmsim.agent.control.StaticController import StaticController
+from swarmsim.world.spawners.DonutSpawner import DonutAgentSpawner
+from swarmsim.world.spawners.AgentSpawner import PointAgentSpawner
+from swarmsim.agent.MazeAgent import MazeAgent, MazeAgentConfig
+from swarmsim.world.simulate import main as sim
+from swarmsim.sensors.BinaryFOVSensor import BinaryFOVSensor
+from swarmsim.agent.control.BinaryController import BinaryController
+from swarmsim.agent.control.HumanController import HumanController
+from swarmsim.agent.control.StaticController import StaticController
+from swarmsim.world.objects.StaticObject import StaticObject, StaticObjectConfig
+from swarmsim.world.objects.Wall import Wall
+
+# world
+world_config = RectangularWorldConfig(size=(10, 10), time_step=1 / 40)
+world = RectangularWorld(world_config)
+
+# spawned binary controller agent
+controller = StaticController(output=[0.01, 0])
+agent = MazeAgent(MazeAgentConfig(position=(5, 5), agent_radius=0.1, controller=controller), world)
+sensor = BinaryFOVSensor(agent, theta=0.45, distance=2, bias=0)
+agent.sensors.append(sensor)
+controller = BinaryController((0.27, -0.6), (0.27, 0.6))
+agent.controller = controller
+
+# spawner
+spawner = PointAgentSpawner(world, n=10, facing="away", avoid_overlap=True, agent=agent, mode="oneshot")
+world.spawners.append(spawner)
+
+# this is the part we are testing
+world.population.addListener("append", print)
+
+sim(world, start_paused=True)

--- a/src/swarmsim/world/World.py
+++ b/src/swarmsim/world/World.py
@@ -169,7 +169,7 @@ class World:
         #: Metrics to calculate behaviors.
         self.metrics: list[AbstractMetric] = []
         #: The list of world objects.
-        self.objects: list[Agent] = []
+        self.objects: HookList[Agent] = HookList()
         self.goals = config.goals
         self.meta = config.metadata
         self.gui = None

--- a/src/swarmsim/world/World.py
+++ b/src/swarmsim/world/World.py
@@ -144,6 +144,17 @@ class AbstractWorldConfig:
     #         goal.range *= zoom
     #     # self.init_type.rescale(zoom)
 
+class HookList(list):
+    listeners = {}
+    def addListener(self, target, listener):
+        if target not in self.listeners:
+            self.listeners[target] = []
+        self.listeners[target].append(listener)
+    def append(self, item):
+        super().append(item)
+        for listener in self.listeners["append"]:
+            listener(item)
+
 
 class World:
     """Base world class.
@@ -152,7 +163,7 @@ class World:
         self.config = config
         config = replace(config)
         #: List of agents in the world.
-        self.population: list[Agent] = []
+        self.population: HookList[Agent] = HookList()
         #: List of spawners which create agents or objects.
         self.spawners: list[Spawner] = []
         #: Metrics to calculate behaviors.


### PR DESCRIPTION
I use HookList, a subclass of list, to add this listener functionality without changing the current usage of World.population.

EDIT: I have now done the same for World.objects

EDIT: This is the most benign pr plz merge :face_holding_back_tears: 