### PR TITLE
Overhaul hooklist API to fully catch all add/delete events

### DIFF
--- a/demo/population_hook_test.py
+++ b/demo/population_hook_test.py
@@ -30,6 +30,7 @@ spawner = PointAgentSpawner(world, n=10, facing="away", avoid_overlap=True, agen
 world.spawners.append(spawner)
 
 # this is the part we are testing
-world.population.addListener("append", print)
+world.population.register_add_callback(lambda x: print(f"added {x}"))
+world.population.register_del_callback(lambda x: print(f"deleted {x}"))
 
 sim(world, start_paused=True)

--- a/src/swarmsim/sensors/BinaryFOVSensor.py
+++ b/src/swarmsim/sensors/BinaryFOVSensor.py
@@ -113,6 +113,9 @@ class BinaryFOVSensor(AbstractSensor):
             #   only check for LOS collisions every n timesteps.
             return
 
+        if not world.quad:
+            return
+
         self.time_since_last_sensing = 0
         sensor_origin = self.agent.getPosition()
 
@@ -272,7 +275,7 @@ class BinaryFOVSensor(AbstractSensor):
                     xadd(radius * yts)
 
         # this padding of the rectangle is to account for and detect agents that would only be seen by the whisker circle intercept correction
-        padding = 0 if self.detect_only_origins else world.maxAgentRadius
+        padding = 0 if self.detect_only_origins else world.max_agent_r
 
         # positions are relative until now, make them absolute for the return
         return [position[0] + xmin - padding, position[1] + ymin - padding, position[0] + xmax + padding, position[1] + ymax + padding]

--- a/src/swarmsim/sensors/BinaryFOVSensor.py
+++ b/src/swarmsim/sensors/BinaryFOVSensor.py
@@ -113,10 +113,12 @@ class BinaryFOVSensor(AbstractSensor):
             #   only check for LOS collisions every n timesteps.
             return
 
+        self.time_since_last_sensing = 0
+
         if not world.quad:
+            self.determineState(False, None, world)
             return
 
-        self.time_since_last_sensing = 0
         sensor_origin = self.agent.getPosition()
 
         # use world.quad that tracks agent positions to retrieve the agents within the minimal rectangle that contains the FOV sector

--- a/src/swarmsim/util/collections.py
+++ b/src/swarmsim/util/collections.py
@@ -267,6 +267,8 @@ class HookList(list):
         return super().pop(index)
 
     def remove(self, value):
+        for func in self._del_callbacks:
+            func(value)
         return super().remove(value)
 
     def __setitem__(self, key, value):

--- a/src/swarmsim/util/collections.py
+++ b/src/swarmsim/util/collections.py
@@ -204,3 +204,84 @@ class FlagSet(set):
             return set(self.flags) < set(other.flags)
         elif isinstance(other, set):
             return set(self.flags) < other
+
+
+def slice_indices(s: slice, max_len: int = 0) -> list[int]:
+    if s.step is None or s.step >= 0 or s.stop is None:
+        stop = max_len if s.stop is None else min(s.stop, max_len)
+    else:  # step is negative, stop is not None. Ignore stop
+        stop = max_len
+    return list(range(stop))[s]
+
+
+class HookList(list):
+    def __init__(self, iterable=None, add_callbacks=None, del_callbacks=None):
+        if iterable is None:
+            iterable = []
+        super().__init__(iterable)
+        self._add_callbacks = [] if add_callbacks is None else add_callbacks
+        self._del_callbacks = [] if del_callbacks is None else del_callbacks
+        for func in self._add_callbacks:
+            for obj in self:
+                func(obj)
+
+    def register_add_callback(self, func):
+        self._add_callbacks.append(func)
+
+    def register_del_callback(self, func):
+        self._del_callbacks.append(func)
+
+    def append(self, obj):
+        for func in self._add_callbacks:
+            func(obj)
+        return super().append(obj)
+
+    def extend(self, iterable):
+        li = list(iterable)
+        for func in self._add_callbacks:
+            for obj in li:
+                func(obj)
+        return super().extend(li)
+
+    def insert(self, index, obj):
+        super().insert(index, obj)
+        for func in self._add_callbacks:
+            func(obj)
+
+    def __iadd__(self, value):
+        for func in self._add_callbacks:
+            for obj in value:
+                func(obj)
+        return super().__iadd__(value)
+
+    def __imul__(self, value):
+        for func in self._add_callbacks:
+            for _i in range(value):
+                for obj in self:
+                    func(obj)
+        return super().__imul__(value)
+
+    def pop(self, index=-1):
+        for func in self._del_callbacks:
+            func(self[index])
+        return super().pop(index)
+
+    def remove(self, value):
+        return super().remove(value)
+
+    def __setitem__(self, key, value):
+        n = len(self)
+        if isinstance(key, slice):
+            indices = slice_indices(key, n)
+            for func in self._del_callbacks:
+                for i in indices:
+                    func(self[i])
+            for func in self._add_callbacks:
+                for obj in value:
+                    func(obj)
+        else:
+            for func in self._del_callbacks:
+                func(self[key])
+            for func in self._add_callbacks:
+                func(value)
+        super().__setitem__(key, value)

--- a/src/swarmsim/world/World.py
+++ b/src/swarmsim/world/World.py
@@ -32,6 +32,7 @@ from ..config import store, filter_unexpected_fields, get_class_from_dict, get_a
 
 from ..util.asdict import asdict
 from ..util.collections import FlagSet
+from ..util.collections import HookList
 
 from ..agent.Agent import Agent
 from .spawners.Spawner import Spawner
@@ -144,16 +145,16 @@ class AbstractWorldConfig:
     #         goal.range *= zoom
     #     # self.init_type.rescale(zoom)
 
-class HookList(list):
-    def __init__(self):
-        super().__init__()
-        self.listeners = {"append": []}
-    def addListener(self, target, listener):
-        self.listeners[target].append(listener)
-    def append(self, item):
-        super().append(item)
-        for listener in self.listeners["append"]:
-            listener(item)
+# class HookList(list):
+#     def __init__(self):
+#         super().__init__()
+#         self.listeners = {"append": []}
+#     def addListener(self, target, listener):
+#         self.listeners[target].append(listener)
+#     def append(self, item):
+#         super().append(item)
+#         for listener in self.listeners["append"]:
+#             listener(item)
 
 
 class World:
@@ -163,13 +164,13 @@ class World:
         self.config = config
         config = replace(config)
         #: List of agents in the world.
-        self.population: HookList[Agent] = HookList()
+        self._population: HookList[Agent] = HookList()
         #: List of spawners which create agents or objects.
         self.spawners: list[Spawner] = []
         #: Metrics to calculate behaviors.
         self.metrics: list[AbstractMetric] = []
         #: The list of world objects.
-        self.objects: HookList[Agent] = HookList()
+        self._objects: HookList[Agent] = HookList()
         self.goals = config.goals
         self.meta = config.metadata
         self.gui = None
@@ -183,6 +184,22 @@ class World:
         #: Also may be used to seed RNG for agents, spawners, etc.
         self.rng: np.random.Generator
         self.flags = FlagSet(config.flags)
+
+    @property
+    def population(self):
+        return self._population
+
+    @population.setter
+    def population(self, value):
+        self._population[:] = value
+
+    @property
+    def objects(self):
+        return self._objects
+
+    @objects.setter
+    def objects(self, value):
+        self._objects[:] = value
 
     def set_seed(self, seed):
         self.seed = np.random.randint(0, 2**31) if seed is None else seed


### PR DESCRIPTION
* Moved `HookList` to `utils.py`
* `World.population` and `World.objects` are now properties
* Fixed `World.quad` not being defined at init time
* `BinaryFOVSensor` will **skip update** if `world.quad is None`
* HookLists now properly calls add/delete callbacks on all list modification operations, i.e. extend, insert, __setitem__, etc.
  * Previously, HookList only notified callbacks on .append
  * `HookList.__setitem__` (i.e. `population[:] = iterable`) calls del_callback on the items being replaced and add_callback on the new items
  * each `func in HookList._add_callbacks` is called for:
    * `HookList.__init__`  (if you somehow manage to create a new one with callbacks on it)
    * `HookList.append`
    * `HookList.extend`
    * `HookList.insert`
    * `HookList.__iadd__`
    * `HookList.__imul__`
    * `HookList.__setitem__`
  * each `func in HookList._del_callbacks` is called for:
    * `HookList.pop`
    * `HookList.remove`
    * `HookList.__setitem__`