### PR TITLE
properly implemented seeding for BinaryFOVSensor (probably)

### DIFF
--- a/src/swarmsim/sensors/AbstractSensor.py
+++ b/src/swarmsim/sensors/AbstractSensor.py
@@ -72,7 +72,8 @@ class AbstractSensor:
             elif hasattr(self.agent, 'rng'):
                 self.seed = self.agent.rng.integers(0, 2**31)
             else:
-                self.seed = int(np.random.randint(0, 2**31))
+                temp_rng = np.random.default_rng(None)
+                self.seed = int(temp_rng.integers(0, 2**31))
         else:
             self.seed = seed
         self.rng = np.random.default_rng(self.seed)

--- a/src/swarmsim/sensors/AbstractSensor.py
+++ b/src/swarmsim/sensors/AbstractSensor.py
@@ -13,7 +13,8 @@ import numpy as np
 class AbstractSensor:
     config_vars = ['static_position', 'n_possible_states', 'show']
 
-    def __init__(self, agent=None, parent=None, static_position=None, n_possible_states=0, draw=True, **kwargs):
+    def __init__(self, agent=None, parent=None, static_position=None, n_possible_states=0,
+                 draw=True, seed=None, **kwargs):
         """Sensor class for the agent.
 
         Sensors should typically have a parent that is assigned to them that must be of subclass 'Agent'
@@ -31,6 +32,7 @@ class AbstractSensor:
         self.current_state = 0
         self.detection_id = 0
         self.goal_detected = False
+        self.set_seed(seed)
 
     def step(self, world):
         if self.agent is None and self.static_position is None:
@@ -62,3 +64,16 @@ class AbstractSensor:
             self.parent = parent
         elif self.parent is None or parent is ...:
             self.parent = agent
+
+    def set_seed(self, seed):
+        if seed is None:
+            if hasattr(self.parent, 'rng'):
+                self.seed = self.parent.rng.integers(0, 2**31)
+            elif hasattr(self.agent, 'rng'):
+                self.seed = self.agent.rng.integers(0, 2**31)
+            else:
+                self.seed = int(np.random.randint(0, 2**31))
+        else:
+            self.seed = seed
+        self.rng = np.random.default_rng(self.seed)
+        return self.seed

--- a/src/swarmsim/sensors/BinaryFOVSensor.py
+++ b/src/swarmsim/sensors/BinaryFOVSensor.py
@@ -69,7 +69,7 @@ class BinaryFOVSensor(AbstractSensor):
         target_team=None,
         **kwargs
     ):
-        super().__init__(agent=agent, parent=parent)
+        super().__init__(agent=agent, parent=parent, seed=seed, **kwargs)
         self.angle = 0.0
         self.theta = theta
         self.bias = bias
@@ -98,10 +98,6 @@ class BinaryFOVSensor(AbstractSensor):
                 self.theta = np.radians(self.theta)
 
         self.r = distance
-
-        self.seed = seed
-        if self.seed is not None:
-            np.random.seed(self.seed)
 
     def checkForLOSCollisions(self, world: RectangularWorld) -> None:
         # Mathematics obtained from Sundaram Ramaswamy
@@ -342,7 +338,7 @@ class BinaryFOVSensor(AbstractSensor):
         invert = self.invert
         if real_value:
             # Consider Reporting False Negative
-            if np.random.random_sample() < self.fn:
+            if self.rng.random() < self.fn:
                 self.agent_in_sight = None
                 self.current_state = 1 if invert else 0
                 self.detection_id = 0
@@ -354,7 +350,7 @@ class BinaryFOVSensor(AbstractSensor):
 
         else:
             # Consider Reporting False Positive
-            if np.random.random_sample() < self.fp:
+            if self.rng.random() < self.fp:
                 self.agent_in_sight = None
                 self.detection_id = 0
                 self.current_state = 0 if invert else 1


### PR DESCRIPTION
I didn't update BinaryFOVSensor to use the new seeding system back when I introduced in 6f0ab4c2c7713b3c29aeeeae1a62bd02a89d828c.

Now, BinaryFOVSensor should attempt to seed its own RNG in this order:

1. `seed` arg in `BinaryFOVSensor.__init__()` (or `seed` in yaml config)
2. `BinaryFOVSensor.parent.rng`
3. `BinaryFOVSensor.agent.rng`
4. System time (`np.random.default_rng(None)`)

`BinaryFOVSensor.rng` is now the rng that should be used within the class/instance, rather than RandomState [np.random.random](https://numpy.org/doc/stable/reference/random/legacy.html) which is now deprecated.