### PR TITLE
BREAKING: Multiple `selected` agents for agentGUI

### DIFF
--- a/src/swarmsim/gui/abstractGUI.py
+++ b/src/swarmsim/gui/abstractGUI.py
@@ -1,3 +1,6 @@
+from ..agent.Agent import Agent
+
+
 class AbstractGUI:
     def __init__(self, x=0, y=0, w=0, h=0):
         self.x = x
@@ -6,10 +9,47 @@ class AbstractGUI:
         self.h = h
         self.track_all_events = False
         self.track_all_mouse = False
+        self._selected = []
 
-    def set_selected(self, agent):
-        # print("Attaching New Agent")
+    def on_set_selected_single(self, agent: Agent):
         pass
+
+    def on_set_selected_multiple(self, agents):
+        pass
+
+    def on_clear_selected(self, previously_selected):
+        pass
+
+    def on_selected_event(self, prev, new):
+        pass
+
+    @property
+    def selected(self):
+        return self._selected
+
+    @selected.setter
+    def selected(self, agents):
+        prev = self._selected
+        self.on_selected_event(prev, agents)
+        if isinstance(agents, Agent):
+            self._selected = [agents]
+            self.on_set_selected_single(agents)
+        else:
+            self._selected = agents
+            if agents:
+                self.on_set_selected_multiple(agents)
+
+        if prev and not self._selected:
+            self.on_clear_selected(prev)
+
+    def set_selected(self, agents):
+        self.selected = agents
+
+    def clear_selected(self):
+        prev = self._selected
+        self._selected = []
+        self.on_selected_event(prev, self._selected)
+        self.on_clear_selected(prev)
 
     def draw(self, screen, offset=((0, 0), 1.0)):
         pass

--- a/src/swarmsim/gui/agentGUI.py
+++ b/src/swarmsim/gui/agentGUI.py
@@ -30,7 +30,6 @@ class DifferentialDriveGUI(AbstractGUI):
     world = None
     title = None
     subtitle = None
-    selected = None
     text_baseline = 10
     sim_paused = False
 
@@ -41,10 +40,6 @@ class DifferentialDriveGUI(AbstractGUI):
         self.speed = None
         self.position = "absolute"
         self.mouse_pos = (0, 0)
-
-    def set_selected(self, agent: DifferentialDriveAgent):
-        super().set_selected(agent)
-        self.selected = agent
 
     def set_title(self, title, subtitle=None):
         self.title = title
@@ -78,7 +73,7 @@ class DifferentialDriveGUI(AbstractGUI):
             mx, my = round(mx, 4), round(my, 4)
             self.appendTextToGUI(screen, timing)  # type: ignore[reportAttributeAccessIssue]
             if self.selected:
-                a: MazeAgent = self.selected
+                a: MazeAgent = self.selected[0]
                 heading = a.get_heading() % (2 * PI) / 2 / PI * 360
                 dx, dy = a.dpos
                 name = a.name


### PR DESCRIPTION
This is a breaking change, as I've changed `AgentGui.selected` from type `Agent` to type `list[Agent]`.

This change allows for the future possibility of selecting multiple agents, although there are no provisions to select multiple agents through the UI yet.